### PR TITLE
fix: add request for palm `get_receipt_page_url`

### DIFF
--- a/hyperpay/views.py
+++ b/hyperpay/views.py
@@ -304,6 +304,7 @@ class HyperPayResponseView(EdxOrderPlacementMixin, View):
             return redirect(reverse('payment_error'))
         self.create_order(request, basket)
         receipt_url = get_receipt_page_url(
+            request=request,
             order_number=basket.order_number,
             site_configuration=basket.site.siteconfiguration
         )


### PR DESCRIPTION
# Description
 **Hyperpay migration to palm.**
The method `get_receipt_page_url` now needs request arg.

Ecommerce PR: https://github.com/openedx/ecommerce/pull/3745 https://github.com/openedx/ecommerce/pull/3745/files#diff-487f124ede8c2f9a1b9d64b7c32f5f4495863135c0e3ac016fa3bffed16d34f3R47
## Testing
Configure a site with payment config.
Configure a course with verified or some payment mode.
Activate hyperpay and hyperpay mada processors flag
[Screencast from 16-02-24 15:44:39.webm](https://github.com/nelc/ecommerce-hyperpay/assets/51926076/3107a7cf-685b-408f-9f1d-9f7c7b0e4317)
![2024-02-16_16-26](https://github.com/nelc/ecommerce-hyperpay/assets/51926076/8c10b468-2201-42f4-96bc-b0061431f9a6)

Pay for the course using test credentials, you could use this [branch] for local dev kit (https://github.com/nelc/nelc-dev-kit/tree/jlc/payment_processors_config) .

### Before 
After ending a payment in the redirection of success, the payment flow crashes.
![Screenshot from 2024-02-16 15-50-34](https://github.com/nelc/ecommerce-hyperpay/assets/51926076/eb3a3648-e60f-41d0-8b2b-731102fb6a7c)
### After
The payment flow using hyperpay is successful.
![2024-02-16_16-23](https://github.com/nelc/ecommerce-hyperpay/assets/51926076/52fdd5dd-f04d-4949-a86f-dfe276f27727)
![2024-02-16_16-21](https://github.com/nelc/ecommerce-hyperpay/assets/51926076/0060c6d4-8464-4b35-8e2b-569ca57370a4)
https://drive.google.com/file/d/1lZfvABWE4ORi2W8Sy-2WWr6h-qSHeq6C/view?usp=drive_link

