### PR TITLE
Jlc/security upgrade

### DIFF
--- a/hyperpay/processors.py
+++ b/hyperpay/processors.py
@@ -190,6 +190,7 @@ class HyperPay(BasePaymentProcessor):
             'locale': request.LANGUAGE_CODE.split('-')[0],
             'csrfmiddlewaretoken': get_token(request),
             'integrity': checkout_data['integrity'],
+            'hyper_pay_api_base_url': self.hyper_pay_api_base_url,
         }
         return transaction_parameters
 

--- a/hyperpay/processors.py
+++ b/hyperpay/processors.py
@@ -135,14 +135,15 @@ class HyperPay(BasePaymentProcessor):
             basket_data.update(cart_item)
         return basket_data
 
-    def _get_checkout_id(self, basket, request):
+    def _get_checkout_data(self, basket, request):
         """
-        Prepare the checkout and return the checkout ID.
+        Prepare the checkout and return the checkout data.
         """
         checkouts_api_url = self.hyper_pay_api_base_url + self.CHECKOUTS_ENDPOINT
         request_data = {
             'entityId': self.entity_id,
-            'paymentType': self.PAYMENT_TYPE
+            'paymentType': self.PAYMENT_TYPE,
+            'integrity': True,
         }
         if self.test_mode:
             request_data['testMode'] = self.test_mode
@@ -169,15 +170,16 @@ class HyperPay(BasePaymentProcessor):
             raise HyperPayException(
                 'Error creating checkout. HyperPay status code: {}'.format(result_code)
             )
-        return data['id']
+        return data
 
     def get_transaction_parameters(self, basket, request=None, use_client_side_checkout=False, **kwargs):
         """
         Return the transaction parameters needed for this processor.
         """
+        checkout_data = self._get_checkout_data(basket, request)
         payment_widget_js_url = '{}?{}'.format(
             self.hyper_pay_api_base_url + self.PAYMENT_WIDGET_JS_PATH,
-            urlencode({'checkoutId': self._get_checkout_id(basket, request)})
+            urlencode({'checkoutId': checkout_data['id']})
         )
         transaction_parameters = {
             'payment_widget_js': payment_widget_js_url,
@@ -187,6 +189,7 @@ class HyperPay(BasePaymentProcessor):
             'payment_mode': self.PAYMENT_MODE,
             'locale': request.LANGUAGE_CODE.split('-')[0],
             'csrfmiddlewaretoken': get_token(request),
+            'integrity': checkout_data['integrity'],
         }
         return transaction_parameters
 

--- a/hyperpay/templates/payment/hyperpay.html
+++ b/hyperpay/templates/payment/hyperpay.html
@@ -4,6 +4,14 @@
 <!DOCTYPE html>
 <html lang="en">
     <head>
+        <meta http-equiv="Content-Security-Policy"
+        content="
+        style-src 'self' {{ hyper_pay_api_base_url }} 'unsafe-inline' ;
+        frame-src 'self' {{ hyper_pay_api_base_url }};
+        script-src 'self' {{ hyper_pay_api_base_url }} 'nonce-{{ nonce_id }}' ;
+        connect-src 'self' {{ hyper_pay_api_base_url }};
+        img-src 'self' {{ hyper_pay_api_base_url }};
+        ">
         <meta charset="UTF-8">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <title>{% trans "HyperPay" %} - {{ payment_mode }}</title>
@@ -21,8 +29,8 @@
             {% endblock %}
         {% endcompress %}
         <script src="{{ payment_widget_js }}" integrity="{{ integrity }}" crossorigin="anonymous"></script>
-        <script src="https://code.jquery.com/jquery.js" type="text/javascript"></script>
-        <script type="text/javascript">
+        <script src="https://code.jquery.com/jquery.js" type="text/javascript" nonce="{{ nonce_id }}"></script>
+        <script type="text/javascript" nonce="{{ nonce_id }}">
             var wpwlOptions = {
               style: 'logos',
               brandDetection: true,
@@ -49,13 +57,13 @@
         {% include 'edx/partials/_student_navbar.html' %}
         <form action="{{ payment_result_url }}" class="paymentWidgets" data-brands="{{ brands }}">
         </form>
-        <script type="text/javascript" src="{% url 'javascript-catalog' %}"></script>
+        <script type="text/javascript" src="{% url 'javascript-catalog' %}" nonce="{{ nonce_id }}"></script>
         {% compress js %}
-            <script src="{% static 'bower_components/requirejs/require.js' %}"></script>
-            <script src="{% static 'js/config.js' %}"></script>
+            <script src="{% static 'bower_components/requirejs/require.js' %}" nonce="{{ nonce_id }}"></script>
+            <script src="{% static 'js/config.js' %}" nonce="{{ nonce_id }}"></script>
 
             Note: django-compressor does not recognize the data-main attribute. Load the main script separately.
-            <script src="{% static 'js/common.js' %}"></script>
+            <script src="{% static 'js/common.js' %}" nonce="{{ nonce_id }}"></script>
         {% endcompress %}
     </body>
 </html>

--- a/hyperpay/templates/payment/hyperpay.html
+++ b/hyperpay/templates/payment/hyperpay.html
@@ -20,7 +20,7 @@
             {% block stylesheets %}
             {% endblock %}
         {% endcompress %}
-        <script src="{{ payment_widget_js }}"></script>
+        <script src="{{ payment_widget_js }}" integrity="{{ integrity }}" crossorigin="anonymous"></script>
         <script src="https://code.jquery.com/jquery.js" type="text/javascript"></script>
         <script type="text/javascript">
             var wpwlOptions = {

--- a/hyperpay/views.py
+++ b/hyperpay/views.py
@@ -7,6 +7,7 @@ import logging
 import re
 from enum import Enum
 from urllib.parse import urlencode
+import uuid
 
 import requests
 from cryptography.fernet import Fernet
@@ -83,7 +84,9 @@ class HyperPayPaymentPageView(View):
         """
         Handles the POST request.
         """
-        return render(request, self.template_name, request.POST.dict())
+        context = request.POST.dict()
+        context["nonce_id"] = str(uuid.uuid4())
+        return render(request, self.template_name, context)
 
 
 class HyperPayResponseView(EdxOrderPlacementMixin, View):


### PR DESCRIPTION
# Description

Following the 3 steps of upgrade for hyperpay.
PCI DSS v4.0 Updates and Required Actions for
CopyAndPay integration

# TEst in local env
- checkout this branch
- Configure a course in your local env with hyperpay credentials.

- Follow the payment flow and check the HTML document of `/payment/hyperpay/pay/`
### Before
![2025-03-27_16-58](https://github.com/user-attachments/assets/25aa31c5-a559-452f-81c5-db10289f5bd4)
![2025-03-27_17-01](https://github.com/user-attachments/assets/19f69e72-8931-41f2-8193-8fe4d5a2e7d2)

### After
- check s1,s2 integrity is sent. for s3 the CSP is generated and created a nonce_id [nonces](https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/CSP)
![2025-03-27_18-20](https://github.com/user-attachments/assets/fd35fa0f-daab-413c-890d-560386e028c0)
![image](https://github.com/user-attachments/assets/05d4724f-fb35-4e14-bbda-4892ea159c45)

#### Check a full payment is working with hyperpay test credentials
[Screencast from 27-03-25 18:32:34.webm](https://github.com/user-attachments/assets/4ccae880-cb26-4c18-a3f0-fc7e524be6d3)


**Jira story**: https://edunext.atlassian.net/browse/FUTUREX-1117?atlOrigin=eyJpIjoiZWI3ODU4NDVmMzM2NDAzNGJiMWFmNThiNzg2OTRhMWMiLCJwIjoiaiJ9